### PR TITLE
Fix legacy collection error Add pnt:none to the blocks atlas

### DIFF
--- a/assets/minecraft/atlases/blocks.json
+++ b/assets/minecraft/atlases/blocks.json
@@ -4,6 +4,10 @@
             "type": "directory",
             "source": "custom",
             "prefix": "custom/"
+        },
+        {
+            "type": "single",
+            "resource": "pnt:none"
         }
     ]
 }


### PR DESCRIPTION
Fix legacy collection error
Add pnt:none to the blocks atlas