### PR TITLE
[skip ci] Update deprecated GH actions

### DIFF
--- a/.github/workflows/updatepack.yml
+++ b/.github/workflows/updatepack.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # A non-shallow repository clone is required
       - name: Run PackSquash
-        uses: ComunidadAylas/PackSquash-action@v3
+        uses: ComunidadAylas/PackSquash-action@v4
       - name: Download optimized pack
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Optimized pack
       - name: Tag and create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v4
         with:
           tag_name: action-v${{ github.run_number }}
           files: pack.zip

--- a/.github/workflows/updatepack.yml
+++ b/.github/workflows/updatepack.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           name: Optimized pack
       - name: Tag and create release
-        uses: softprops/action-gh-release@v4
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: action-v${{ github.run_number }}
           files: pack.zip


### PR DESCRIPTION
Just wanted to do some touchups to the actions so we are up to date with the latest node. Thanks 👍🏻 